### PR TITLE
Associate twitter_followings with accounts

### DIFF
--- a/app/controllers/twitter_followings_controller.rb
+++ b/app/controllers/twitter_followings_controller.rb
@@ -2,19 +2,16 @@
 
 class TwitterFollowingsController < ApplicationController
   before_action :authenticate
+  before_action :twitter_followings, :set_form, only: %i[new create]
 
   def index
-    @twitter_followings = TwitterFollowing.all
+    @twitter_followings = current_account.twitter_followings
   end
 
   def new
-    @twitter_following = TwitterFollowing.new
-    @form = Om::FollowTwitterUserForm.new
   end
 
   def create
-    @twitter_following = TwitterFollowing.new
-    @form = Om::FollowTwitterUserForm.new
     if @form.submit params.require(:twitter_following)
       redirect_to twitter_followings_path
     else
@@ -23,8 +20,18 @@ class TwitterFollowingsController < ApplicationController
   end
 
   def destroy
-    @twitter_following = TwitterFollowing.find(params[:id])
+    @twitter_following = current_account.twitter_followings.find(params[:id])
     Om::Twitter::UnfollowUser.new(@twitter_following).perform
     redirect_to twitter_followings_path, notice: t("twitter_followings.destroy.flash.notice"), status: :see_other
+  end
+
+  private
+
+  def twitter_followings
+    @twitter_following = current_account.twitter_followings.new
+  end
+
+  def set_form
+    @form = Om::FollowTwitterUserForm.new(account_id: current_account.id)
   end
 end

--- a/app/forms/om/follow_twitter_user_form.rb
+++ b/app/forms/om/follow_twitter_user_form.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Om::FollowTwitterUserForm < Om::Form
+  attribute :account_id, :integer
   attribute :username, :string
 
   validates_presence_of :username
 
   def perform
-    service = Om::Twitter::FollowUser.new(username)
+    service = Om::Twitter::FollowUser.new(account_id, username)
     return true if service.perform
 
     service.errors.each do |error|

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -9,6 +9,7 @@ class Account < ApplicationRecord
   )
 
   has_many :rss_feeds, dependent: :destroy
+  has_many :twitter_followings, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 end

--- a/app/models/twitter_following.rb
+++ b/app/models/twitter_following.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TwitterFollowing < ApplicationRecord
+  belongs_to :account
+
   has_many :tweets, dependent: :destroy
 
   validates :username, presence: true

--- a/app/services/om/queries/grouped_elements.rb
+++ b/app/services/om/queries/grouped_elements.rb
@@ -32,6 +32,7 @@ class Om::Queries::GroupedElements
   def grouped_tweets
     Tweet
       .includes(:twitter_following, :tweet_uris)
+      .where(twitter_following: {account_id: account.id})
       .order(tweeted_at: :desc)
       .limit(THRESHOLD)
       .group_by { |tweet| tweet.tweeted_at.to_date }

--- a/app/services/om/twitter/follow_user.rb
+++ b/app/services/om/twitter/follow_user.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Om::Twitter::FollowUser < Om::Service
-  def initialize(username)
+  def initialize(account_id, username)
+    @account_id = account_id
     @username = username
     super()
   end
@@ -10,9 +11,10 @@ class Om::Twitter::FollowUser < Om::Service
 
   private
 
-  attr_reader :username
-
   def create_twitter_following!
-    TwitterFollowing.create!(username: username)
+    TwitterFollowing.create!(
+      account_id: @account_id,
+      username: @username
+    )
   end
 end

--- a/db/migrate/20220121210752_add_account_id_to_twitter_followings.rb
+++ b/db/migrate/20220121210752_add_account_id_to_twitter_followings.rb
@@ -1,0 +1,7 @@
+class AddAccountIdToTwitterFollowings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :twitter_followings, :account_id, :bigint, null: false
+    add_foreign_key :twitter_followings, :accounts
+    add_index :twitter_followings, :account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_04_002804) do
-
+ActiveRecord::Schema.define(version: 2022_01_21_210752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -106,6 +105,8 @@ ActiveRecord::Schema.define(version: 2021_12_04_002804) do
     t.string "username", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "account_id", null: false
+    t.index ["account_id"], name: "index_twitter_followings_on_account_id"
   end
 
   add_foreign_key "account_login_change_keys", "accounts", column: "id"
@@ -117,4 +118,5 @@ ActiveRecord::Schema.define(version: 2021_12_04_002804) do
   add_foreign_key "rss_feeds", "accounts"
   add_foreign_key "tweet_uris", "tweets"
   add_foreign_key "tweets", "twitter_followings"
+  add_foreign_key "twitter_followings", "accounts"
 end

--- a/spec/factories/twitter_followings.rb
+++ b/spec/factories/twitter_followings.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :twitter_following do
+    account
     username { "rails" }
   end
 

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -15,8 +15,16 @@ describe "homepage", js: true do
       )
     end
 
+    let(:twitter_following) do
+      FactoryBot.create(:twitter_following, account: account)
+    end
+
     let!(:tweet) do
-      FactoryBot.create(:tweet, tweeted_at: Time.zone.local(2020, 12, 4))
+      FactoryBot.create(
+        :tweet,
+        twitter_following: twitter_following,
+        tweeted_at: Time.zone.local(2020, 12, 4)
+      )
     end
 
     it "I can see the timeline" do

--- a/spec/forms/om/follow_twitter_user_form_spec.rb
+++ b/spec/forms/om/follow_twitter_user_form_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 describe Om::FollowTwitterUserForm do
   subject(:form) { described_class.new }
 
+  let(:account_id) { FactoryBot.create(:account).id }
   let(:username) { "dhh" }
-  let(:params) { {username: username} }
+  let(:params) { {username: username, account_id: account_id} }
 
   let(:service_dbl) do
     instance_double(Om::Twitter::FollowUser, perform: service_succeeded)
@@ -15,7 +16,7 @@ describe Om::FollowTwitterUserForm do
 
   before do
     allow(Om::Twitter::FollowUser).to(
-      receive(:new).with(username).and_return(service_dbl)
+      receive(:new).with(account_id, username).and_return(service_dbl)
     )
   end
 

--- a/spec/services/om/queries/grouped_elements_spec.rb
+++ b/spec/services/om/queries/grouped_elements_spec.rb
@@ -9,20 +9,47 @@ describe Om::Queries::GroupedElements do
     let(:account) { FactoryBot.create(:account) }
     let(:fetch) { subject.fetch }
 
+    let(:twitter_following) do
+      FactoryBot.create(:twitter_following, account: account)
+    end
+
     context "when there is only one element" do
-      let!(:tweet) { FactoryBot.create(:tweet) }
+      let!(:tweet) do
+        FactoryBot.create(:tweet, twitter_following: twitter_following)
+      end
 
       it "contains the date and the element" do
         expect(fetch.first).to match([tweet.tweeted_at.to_date, [tweet]])
       end
     end
 
+    context "when the element is not associated to the account" do
+      it "doesn't include the tweet" do
+        FactoryBot.create(:tweet)
+        expect(fetch.first).to be_nil
+      end
+
+      it "doesn't include the tweet" do
+        FactoryBot.create(:rss_feed_item)
+        expect(fetch.first).to be_nil
+      end
+    end
+
     context "when there are two elements with different dates" do
       let!(:tweet1) do
-        FactoryBot.create(:tweet, tweeted_at: Time.current.midnight)
+        FactoryBot.create(
+          :tweet,
+          twitter_following: twitter_following,
+          tweeted_at: Time.current.midnight
+        )
       end
+
       let!(:tweet2) do
-        FactoryBot.create(:tweet, tweeted_at: Time.zone.yesterday.midnight)
+        FactoryBot.create(
+          :tweet,
+          twitter_following: twitter_following,
+          tweeted_at: Time.zone.yesterday.midnight
+        )
       end
 
       it "contains the first date" do
@@ -36,7 +63,11 @@ describe Om::Queries::GroupedElements do
 
     context "when there are two different elements for the same date" do
       let!(:tweet) do
-        FactoryBot.create(:tweet, tweeted_at: Time.current.midnight)
+        FactoryBot.create(
+          :tweet,
+          twitter_following: twitter_following,
+          tweeted_at: Time.current.midnight
+        )
       end
 
       let(:rss_feed) { FactoryBot.create(:rss_feed, account: account) }

--- a/spec/services/om/twitter/follow_user_spec.rb
+++ b/spec/services/om/twitter/follow_user_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 describe Om::Twitter::FollowUser do
   describe "#perform" do
-    subject(:service) { described_class.new(username) }
+    subject(:service) { described_class.new(account_id, username) }
 
+    let(:account_id) { FactoryBot.create(:account).id }
     let(:username) { "twitter-username" }
 
     it "creates a new TwitterFollowing" do


### PR DESCRIPTION
## Why

`twitter_followings` (Twitter accounts followed by a user) are not associated with `accounts`.

This results in `twitter_followings` being "shared", with anybody able to see and manage everybody's followings. :sweat: 

## What

- Added `account_id` foreign key to `twitter_followings` table
- Adapted existing services, forms, queries and specs to support this new association and avoid sharing `twitter_followings` between accounts
